### PR TITLE
Add a devcommit type

### DIFF
--- a/docs/versioning.rst
+++ b/docs/versioning.rst
@@ -177,6 +177,29 @@ g9       v1.0.0  1.0.0             ``version --bump major --commit``
 g10              1.0.0.dev1
 =======  ======  ================  =====================================================================================
 
+devcommit
+---
+
+Similar to dev_, except that it uses the commit id instead of distance.
+
+Example:
+
+=======  ======  ================  =====================================================================================
+Commit   Tag     Version           Note (command ran to add tag)
+=======  ======  ================  =====================================================================================
+g1               0.0.0.dev-g1      Initial commit
+g1               0.0.0.dev-g1-dirty  Same as above, only checkout was not clean anymore
+g2               0.0.0.dev-g2
+g3               0.0.0.dev-g3
+g4       v0.1.0  0.1.0             ``version --bump minor --commit``
+g5               0.1.1.dev-g5        (1 commit since tag)
+g6               0.1.1.dev-g6
+g7       v0.1.1  0.1.1             ``version --bump patch --commit``
+g8               0.1.2.dev-g7
+g9       v1.0.0  1.0.0             ``version --bump major --commit``
+g10              1.0.0.dev-g10
+=======  ======  ================  =====================================================================================
+
 
 distance
 --------

--- a/setupmeta/scm.py
+++ b/setupmeta/scm.py
@@ -259,3 +259,14 @@ class Version:
         if self.distance or self.dirty:
             return ".dev%s" % self.distance
         return ""
+
+    @property
+    def devcommit(self):
+        """
+        {devcommit} marker for this version
+
+        :return str: '.dev-{commitid}' for distance > 0, empty string otherwise
+        """
+        if self.distance or self.dirty:
+            return ".dev-%s" % self.commitid
+        return ""

--- a/setupmeta/versioning.py
+++ b/setupmeta/versioning.py
@@ -233,7 +233,7 @@ class Strategy:
             bits = list(bits)
             last = bits[-1]
             prelast = bits[-2]
-            if last and last.text == "dev" and prelast and prelast.text in BUMPABLE:
+            if last and (last.text == "dev" or last.text == "devcommit") and prelast and prelast.text in BUMPABLE:
                 bits[-2] = prelast.auto_bumped()
         result = self.rendered_bits(version, bits) or []
         if extra and self.needs_extra(version):
@@ -309,6 +309,11 @@ class Strategy:
 
             elif main == "dev":
                 main = "{major}.{minor}.{patch}{dev}"
+
+            elif main == "devcommit":
+                main = "{major}.{minor}.{patch}{devcommit}"
+                data["extra"] = "-dirty"
+                data["separator"] = ""
 
             elif main in ("", "default", "post", "tag"):
                 main = data["main"]

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -138,6 +138,8 @@ def test_versioning_variants(*_):
         quick_check("distance", "0.1.5+g123")
         quick_check("post", "0.1.2.post5+g123")
         quick_check("dev", "0.1.3.dev5+g123")
+        quick_check("devcommit", "0.1.3.dev-g123", dirty=False)
+        quick_check("devcommit", "0.1.3.dev-g123-dirty")
         quick_check("tag+dev", "0.1.3.dev5+g123")
         quick_check("build-id", "0.1.5+h543.g123.dirty")
         quick_check("dev+build-id", "0.1.3.dev5+h543.g123.dirty")
@@ -148,6 +150,9 @@ def test_versioning_variants(*_):
         # On tag
         quick_check("dev", "0.1.2", describe="v0.1.2-0-g123", dirty=False)
         quick_check("dev", "0.1.3.dev0+g123", describe="v0.1.2-0-g123", dirty=True)
+        quick_check("devcommit", "0.1.2", describe="v0.1.2", dirty=False)
+        quick_check("devcommit", "0.1.2", describe="v0.1.2-0-g123", dirty=False)
+        quick_check("devcommit", "0.1.3.dev-g123-dirty", describe="v0.1.2-0-g123", dirty=True)
 
         assert "patch version component should be .0" in logged
 


### PR DESCRIPTION
Similar to {dev} but uses commits instead of distance for the suffix.

Allows versions like 0.1.1.dev-d4ae34