### PR TITLE
Add show-next command

### DIFF
--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -90,6 +90,7 @@ Typical usage::
 
     python setup.py version --help              # What were the options?
     python setup.py version                     # Show current version and exit
+    python setup.py version --show-next minor   # Show next minor version and exit
     python setup.py version --bump minor        # Dryrun bump: see what would be done
     python setup.py version --b minor --commit  # Effectively bump
 

--- a/setupmeta/commands.py
+++ b/setupmeta/commands.py
@@ -56,6 +56,7 @@ class VersionCommand(setuptools.Command):
     user_options = [
         ("bump=", "b", "bump specified part of version"),
         ("commit", "c", "commit bump"),
+        ("show-next=", "n", "show what the next bump of the specified part of version will be"),
         ("simulate-branch=", "s", "simulate branch name (useful for testing)"),
     ]
 
@@ -63,10 +64,13 @@ class VersionCommand(setuptools.Command):
         self.bump = None
         self.commit = 0
         self.simulate_branch = None
+        self.show_next = None
 
     def run(self):
         try:
-            if self.bump:
+            if self.show_next:
+                print(self.setupmeta.versioning.get_bump(self.show_next))
+            elif self.bump:
                 self.setupmeta.versioning.bump(self.bump, self.commit, self.simulate_branch)
             else:
                 print(self.setupmeta.version)

--- a/setupmeta/versioning.py
+++ b/setupmeta/versioning.py
@@ -407,6 +407,12 @@ class Versioning:
             setupmeta.warn(msg)
         self.meta.auto_fill("version", rendered, self.scm.name, override=True)
 
+    def get_bump(self, what):
+        if self.problem:
+            setupmeta.abort(self.problem)
+        gv = self.scm.get_version()
+        return self.strategy.bumped(what, gv)
+
     def bump(self, what, commit=False, simulate_branch=None):
         if self.problem:
             setupmeta.abort(self.problem)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -66,6 +66,20 @@ def test_version():
         """,
     )
 
+    run_setup_py(
+        ["version", "-n", "patch"],
+        """
+            [\\d.]+
+        """,
+    )
+
+    run_setup_py(
+        ["version", "--show-next", "major"],
+        """
+            [\\d.]+
+        """,
+    )
+
 
 @patch("sys.stdout.isatty", return_value=True)
 @patch("os.popen", return_value=StringIO("60"))

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -196,6 +196,9 @@ def test_invalid_part():
         with pytest.raises(setupmeta.UsageError):
             versioning.bump("minor")
 
+        with pytest.raises(setupmeta.UsageError):
+            versioning.get_bump("minor")
+
 
 def test_invalid_main():
     with conftest.capture_output() as logged:
@@ -330,3 +333,11 @@ def check_bump(versioning):
 
     with pytest.raises(setupmeta.UsageError):
         versioning.bump("foo")
+
+
+def check_get_bump(versioning):
+    assert versioning.get_bump("major") == "1.0.0"
+    assert versioning.get_bump("minor") == "0.2.0"
+
+    with pytest.raises(setupmeta.UsageError):
+        versioning.get_bump("foo")


### PR DESCRIPTION
Similar to bump shows the version that a bump will increment to without changing anything. Useful for scripts that perfer to handle the tagging themselves.