### PR TITLE
run_program: remove trailing newlines

### DIFF
--- a/setupmeta/__init__.py
+++ b/setupmeta/__init__.py
@@ -189,7 +189,13 @@ def run_program(program, *args, **kwargs):
     trace(trace_msg)
 
     if capture:
-        return merged(output, error if capture == "all" else None)
+        if output[-1:] == '\n':
+            output = output[:-1]
+        if capture == "all":
+            if error[-1:] == '\n':
+                error = error[:-1]
+            return merged(output, error)
+        return merged(output, None)
 
     if p.returncode and fatal:
         print("%s exited with code %s" % (represented, p.returncode))

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -86,6 +86,8 @@ def test_run_program():
         with pytest.raises(SystemExit):
             assert setupmeta.run_program("ls", "foo/does/not/exist", fatal=True)
 
+        assert setupmeta.run_program("echo", capture=True) == ""
+
         assert "exitcode" in out
 
     setupmeta.DEBUG = False


### PR DESCRIPTION
This uses the same method as `subprocess.getstatusoutput`.

It is meant to handle stripping in a central place, e.g. for the `text`
of version information that is used in warnings:

> …/setupmeta/__init__.py:39: UserWarning: patch version component should be .0 for versioning strategy 'branch(master):{major}.{minor}.{distance}+{commitid}', '.4' from current version tag 'v0.1.4-0-g55cfec1
> ' will be ignored
>   warnings.warn(message)

A new `strip` keyword argument could be added to control this behavior, but I do not think it is necessary.