### PR TITLE
tox.ini: do not set unnecessary passenv

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,6 @@ commands = pytest {posargs:-vv --cov-report term-missing --cov=setupmeta/}
 [testenv:coverage]
 deps = coverage
 skip_install = True
-passenv = {[testenv]passenv}
 setenv = COVERAGE_FILE={toxworkdir}/.coverage
 commands = coverage combine
            coverage report -m
@@ -22,7 +21,6 @@ commands = coverage combine
 
 [testenv:codecov]
 description = [only run on CI]: upload coverage data to codecov (depends on coverage running first)
-passenv = {[testenv]passenv}
 deps = codecov
 skip_install = True
 commands = codecov --file "{toxworkdir}/coverage.xml"
@@ -30,14 +28,12 @@ commands = codecov --file "{toxworkdir}/coverage.xml"
 [testenv:docs]
 basepython = python
 skip_install = True
-passenv = {[testenv]passenv}
 deps = readme_renderer
 commands = python setup.py check --strict --restructuredtext
            python setup.py explain -c125
 
 [testenv:style]
 basepython = python
-passenv = {[testenv]passenv}
 skip_install = True
 deps = flake8
        flake8-import-order
@@ -45,7 +41,6 @@ commands = flake8 {posargs:examples/ setupmeta/ tests/ setup.py}
 
 [testenv:security]
 basepython = python
-passenv = {[testenv]passenv}
 skip_install = True
 deps = bandit
 commands = bandit {posargs:-r examples/ setupmeta/ setup.py}


### PR DESCRIPTION
It will use the value from ``testenv`` by default.