### PR TITLE
Push version bumps only when --push is explicitly specified

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,12 @@
 History
 =======
 
+2.4.0 (2019-02-12)
+------------------
+
+* Push version bumps only when ``--push`` is explicitly specified
+
+
 2.3.4 (2019-02-11)
 ------------------
 

--- a/setupmeta/commands.py
+++ b/setupmeta/commands.py
@@ -56,6 +56,7 @@ class VersionCommand(setuptools.Command):
     user_options = [
         ("bump=", "b", "bump specified part of version"),
         ("commit", "c", "commit bump"),
+        ("push", None, "push version bump"),
         ("show-next=", "a", "show what the next bump of the specified part of version will be"),
         ("simulate-branch=", "s", "simulate branch name (useful for testing)"),
     ]
@@ -63,6 +64,7 @@ class VersionCommand(setuptools.Command):
     def initialize_options(self):
         self.bump = None
         self.commit = 0
+        self.push = 0
         self.simulate_branch = None
         self.show_next = None
 
@@ -71,7 +73,7 @@ class VersionCommand(setuptools.Command):
             if self.show_next:
                 print(self.setupmeta.versioning.get_bump(self.show_next))
             elif self.bump:
-                self.setupmeta.versioning.bump(self.bump, self.commit, self.simulate_branch)
+                self.setupmeta.versioning.bump(self.bump, commit=self.commit, push=self.push, simulate_branch=self.simulate_branch)
             else:
                 print(self.setupmeta.version)
 

--- a/setupmeta/versioning.py
+++ b/setupmeta/versioning.py
@@ -417,7 +417,7 @@ class Versioning:
         gv = self.scm.get_version()
         return self.strategy.bumped(what, gv)
 
-    def bump(self, what, commit=False, simulate_branch=None):
+    def bump(self, what, commit=False, push=False, simulate_branch=None):
         if self.problem:
             setupmeta.abort(self.problem)
 
@@ -436,11 +436,14 @@ class Versioning:
         if not commit:
             print("Not committing bump, use --commit to commit")
 
+        if not push:
+            print("Not pushing bump, use --push to push")
+
         vdefs = self.meta.definitions.get("version")
         if vdefs:
-            self.update_sources(next_version, commit, vdefs)
+            self.update_sources(next_version, commit, push, vdefs)
 
-        self.scm.apply_tag(commit, next_version)
+        self.scm.apply_tag(commit, push, next_version)
 
         if not self.strategy.hook:
             return
@@ -449,7 +452,7 @@ class Versioning:
         if setupmeta.is_executable(hook):
             setupmeta.run_program(hook, self.meta.name, branch, next_version, fatal=True, dryrun=not commit, cwd=setupmeta.project_path())
 
-    def update_sources(self, next_version, commit, vdefs):
+    def update_sources(self, next_version, commit, push, vdefs):
         modified = []
         for vdef in vdefs.sources:
             if ".py:" not in vdef.source:
@@ -487,7 +490,7 @@ class Versioning:
         if not modified:
             return
 
-        self.scm.commit_files(commit, modified, next_version)
+        self.scm.commit_files(commit, push, modified, next_version)
 
 
 def updated_line(line, next_version, vdef):

--- a/tests/scenarios/complex/.commands
+++ b/tests/scenarios/complex/.commands
@@ -1,7 +1,7 @@
 version --bump patch
-version --bump minor
+version --bump minor --push
 version --bump major
 version --bump minor --commit
-version --bump major --commit
+version --bump major --commit --push
 version
 explain -c180

--- a/tests/scenarios/complex/expected.txt
+++ b/tests/scenarios/complex/expected.txt
@@ -146,7 +146,7 @@ running version
 'setup.py version --bump patch' exited with code 1:
 error: Can't bump 'patch', it's out of scope of main format '{major}.{minor}.{distance}' acceptable values: major, minor
 
-:: version --bump minor
+:: version --bump minor --push
 WARNING: patch version component should be .0 for versioning strategy...
 WARNING: In setup.py:6 version should be 1.2.0, not 1.0a1
 running version
@@ -168,6 +168,7 @@ WARNING: patch version component should be .0 for versioning strategy...
 WARNING: In setup.py:6 version should be 1.2.0, not 1.0a1
 running version
 Not committing bump, use --commit to commit
+Not pushing bump, use --push to push
 Would update setup.py:6 with: version: 2.0.0
 Would update setup.py:12 with: __version__ = "2.0.0"
 Would update complex/__version__.py:3 with: __version__ = "2.0.0"  # Ignored due to setuptools_scm ref
@@ -175,24 +176,21 @@ Would update complex/__init__.py:7 with: __version__ = '2.0.0'  # Ignored due to
 Would update src/complex/__init__.py:7 with: __version__ = "2.0.0"
 Would run: git add complex/__init__.py complex/__version__.py setup.py src/complex/__init__.py
 Would run: git commit -m "Version 2.0.0"
-Would run: git push origin
 Would run: git tag -a v2.0.0 -m "Version 2.0.0"
-Would run: git push --tags origin
 Would run: <target>/.hooks/bump complex master 2.0.0
 
 :: version --bump minor --commit
 WARNING: patch version component should be .0 for versioning strategy...
 WARNING: In setup.py:6 version should be 1.2.0, not 1.0a1
 running version
+Not pushing bump, use --push to push
 src/complex/__init__.py:7 already has the right version
 Running: git add complex/__init__.py complex/__version__.py setup.py
 Running: git commit -m "Version 1.3.0"
-Running: git push origin
 Running: git tag -a v1.3.0 -m "Version 1.3.0"
-Running: git push --tags origin
 Running: <target>/.hooks/bump complex master 1.3.0
 
-:: version --bump major --commit
+:: version --bump major --commit --push
 running version
 Running: git add complex/__init__.py complex/__version__.py setup.py src/complex/__init__.py
 Running: git commit -m "Version 2.0.0"

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -40,7 +40,7 @@ def test_version():
     run_setup_py(["version", "--bump", "major", "--simulate-branch=HEAD"], "Can't bump branch 'HEAD'")
 
     run_setup_py(
-        ["version", "--bump", "major", "--simulate-branch=master"],
+        ["version", "--bump", "major", "--simulate-branch=master", "--push"],
         """
             Not committing bump, use --commit to commit
             Would run: git tag -a v[\\d.]+ -m "Version [\\d.]+"
@@ -53,7 +53,6 @@ def test_version():
         """
             Not committing bump, use --commit to commit
             Would run: git tag -a v[\\d.]+ -m "Version [\\d.]+"
-            Would run: git push --tags origin
         """,
     )
 
@@ -62,7 +61,6 @@ def test_version():
         """
             Not committing bump, use --commit to commit
             Would run: git tag -a v[\\d.]+ -m "Version [\\d.]+"
-            Would run: git push --tags origin
         """,
     )
 

--- a/tests/test_scm.py
+++ b/tests/test_scm.py
@@ -7,8 +7,8 @@ def test_scm():
     scm = setupmeta.scm.Scm(conftest.TESTS)
     assert scm.get_branch() is None
     assert scm.get_version() is None
-    assert scm.commit_files(False, None, None) is None
-    assert scm.apply_tag(False, None) is None
+    assert scm.commit_files(False, False, None, "") is None
+    assert scm.apply_tag(False, False, "") is None
     assert scm.get_output() is None
 
 
@@ -17,11 +17,11 @@ def test_git():
     assert str(git.get_version()) == "v0.0.0-1-gabc123"
 
     with conftest.capture_output() as out:
-        git.commit_files(False, [], "2.0")
+        git.commit_files(False, False, [], "2.0")
         assert not str(out)
 
-        git.commit_files(False, ["foo"], "2.0")
-        git.apply_tag(False, "2.0")
+        git.commit_files(False, True, ["foo"], "2.0")
+        git.apply_tag(False, True, "2.0")
         assert "Would run: git add foo" in out
         assert 'Would run: git commit -m "Version 2.0"' in out
         assert "Would run: git push origin" in out
@@ -30,11 +30,11 @@ def test_git():
 
     git._has_origin = ""
     with conftest.capture_output() as out:
-        git.commit_files(False, [], "2.0")
+        git.commit_files(False, False, [], "2.0")
         assert not str(out)
 
-        git.commit_files(False, ["foo"], "2.0")
-        git.apply_tag(False, "2.0")
+        git.commit_files(False, True, ["foo"], "2.0")
+        git.apply_tag(False, True, "2.0")
         assert "Would run: git add foo" in out
         assert 'Would run: git commit -m "Version 2.0"' in out
         assert 'Would run: git tag -a v2.0 -m "Version 2.0"' in out

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -323,10 +323,9 @@ def check_bump(versioning):
         versioning.bump("major")
         assert "Not committing bump, use --commit to commit" in out
         assert 'git tag -a v1.0.0 -m "Version 1.0.0"' in out
-        assert "git push --tags origin" in out
 
     with conftest.capture_output() as out:
-        versioning.bump("minor")
+        versioning.bump("minor", push=True)
         assert "Not committing bump, use --commit to commit" in out
         assert 'git tag -a v0.2.0 -m "Version 0.2.0"' in out
         assert "git push --tags origin" in out


### PR DESCRIPTION
Bundling push with commit may be confusing, only push when user explicitly stated `version bump ... --push`