### PR TITLE
Run only if explicitly required

### DIFF
--- a/setupmeta/__init__.py
+++ b/setupmeta/__init__.py
@@ -305,10 +305,6 @@ class temp_resource:
 def meta_command_init(self, dist, **kwargs):
     """Custom __init__ injected to commands decorated with @MetaCommand"""
     self.setupmeta = getattr(dist, "_setupmeta", None)
-    if not self.setupmeta:
-        from distutils.errors import DistutilsClassError
-
-        raise DistutilsClassError("Missing setupmeta information")
     setuptools.Command.__init__(self, dist, **kwargs)
 
 

--- a/setupmeta/commands.py
+++ b/setupmeta/commands.py
@@ -56,6 +56,9 @@ class CheckCommand(check):
         self.reqs = None
 
     def run(self):
+        if not self.setupmeta:
+            return check.run(self)
+
         if count(self.restructuredtext, self.status, self.deptree, self.reqs) == 0:
             self.status = 1
             self.reqs = 1
@@ -115,6 +118,9 @@ class VersionCommand(setuptools.Command):
         self.show_next = None
 
     def run(self):
+        if not self.setupmeta:
+            return
+
         try:
             if self.show_next:
                 print(self.setupmeta.versioning.get_bump(self.show_next))
@@ -250,6 +256,9 @@ class ExplainCommand(setuptools.Command):
         print(")")
 
     def run(self):
+        if not self.setupmeta:
+            return
+
         if self.expand:
             return self.show_expanded_python()
 
@@ -296,6 +305,9 @@ class EntryPointsCommand(setuptools.Command):
     """List entry points for pygradle consumption"""
 
     def run(self):
+        if not self.setupmeta:
+            return
+
         entry_points = self.setupmeta.value("entry_points")
         console_scripts = get_console_scripts(entry_points)
         if not console_scripts:
@@ -358,6 +370,9 @@ class CleanCommand(setuptools.Command):
                 self.delete(full_path)
 
     def run(self):
+        if not self.setupmeta:
+            return
+
         self.deleted = 0
         self.by_ext = collections.defaultdict(int)
         self.clean_direct()
@@ -434,6 +449,9 @@ class TwineCommand(setuptools.Command):
         setupmeta.run_program(*args, fatal=True)
 
     def run(self):
+        if not self.setupmeta:
+            return
+
         if platform.python_implementation() != "CPython":
             abort("twine command not supported on %s" % platform.python_implementation())
 

--- a/setupmeta/hook.py
+++ b/setupmeta/hook.py
@@ -19,22 +19,23 @@ def distutils_hook(dist, *args, **kwargs):
     so we can decorate the 'dist' object appropriately for our own commands
     """
     if dist.script_args and not hasattr(dist, "_setupmeta"):
-        # Add our ._setupmeta object
-        # (distutils calls this several times, we need only one)
+        # Add our ._setupmeta object (distutils calls this several times, we need only one)
         dist._setupmeta = SetupMeta(dist)
         MetaDefs.fill_dist(dist, dist._setupmeta.to_dict())
     return dd_original(dist, *args, **kwargs)
 
 
-# Replace Distribution.parse_command_line so we can inject our parsing
-distutils.dist.Distribution.parse_command_line = distutils_hook
-
-
-def register(*args, **kwargs):
+def register(dist, name, value):
     """ Hook into distutils in order to do our magic
 
     We use this as a 'distutils.setup_keywords' entry point
     We don't need to do anything specific here (in this function)
     But we do need distutils to import this module
     """
-    pass
+    if name == "setup_requires":
+        if value == "setupmeta" or "setupmeta" in value:
+            # Replace Distribution.parse_command_line so we can inject our parsing
+            distutils.dist.Distribution.parse_command_line = distutils_hook
+
+        else:
+            distutils.dist.Distribution.parse_command_line = dd_original

--- a/tests/scenarios/bogus/expected.txt
+++ b/tests/scenarios/bogus/expected.txt
@@ -9,6 +9,7 @@ running explain
              long_description: (README.md  ) # bogus versioning spec This scenario tests a bogus `versioning` specification in `setup.py`
 long_description_content_type: (README.md  ) text/markdown
                          name: (explicit   ) bogus
+               setup_requires: (explicit   ) ["setupmeta"]
                           url: (missing    ) - Consider specifying 'url'
                       version: (git        ) 1.0
                    versioning: (explicit   ) {extra: [], main: function 'main_part'}

--- a/tests/scenarios/bogus/setup.py
+++ b/tests/scenarios/bogus/setup.py
@@ -7,6 +7,7 @@ def main_part(version):
 
 setup(
     name="bogus",
+    setup_requires="setupmeta",
     versioning={
         "main": main_part,
         "extra": [],

--- a/tests/scenarios/disabled/.commands
+++ b/tests/scenarios/disabled/.commands
@@ -1,2 +1,2 @@
-clean
+cleanall
 twine

--- a/tests/scenarios/disabled/.commands
+++ b/tests/scenarios/disabled/.commands
@@ -1,0 +1,2 @@
+clean
+twine

--- a/tests/scenarios/disabled/expected.txt
+++ b/tests/scenarios/disabled/expected.txt
@@ -1,0 +1,25 @@
+:: explain -c180 -r
+running explain
+
+:: explain -d
+running explain
+
+:: explain --expand
+running explain
+
+:: check
+running check
+warning: CheckCommand: missing required meta-data: version, url
+warning: CheckCommand: missing meta-data: either (author and author_email) or (maintainer and maintainer_email) must be supplied
+
+:: entrypoints
+running entrypoints
+
+:: version
+running version
+
+:: clean
+running clean
+
+:: twine
+running twine

--- a/tests/scenarios/disabled/expected.txt
+++ b/tests/scenarios/disabled/expected.txt
@@ -18,8 +18,8 @@ running entrypoints
 :: version
 running version
 
-:: clean
-running clean
+:: cleanall
+running cleanall
 
 :: twine
 running twine

--- a/tests/scenarios/disabled/requirements.txt
+++ b/tests/scenarios/disabled/requirements.txt
@@ -1,0 +1,15 @@
+sqlalchemy
+
+[:python_version < "3.7"]
+aiocontextvars
+
+[mysql]
+aiomysql
+pymysql
+
+[postgresql]
+asyncpg
+psycopg2-binary
+
+[sqlite]
+aiosqlite

--- a/tests/scenarios/disabled/setup.py
+++ b/tests/scenarios/disabled/setup.py
@@ -1,0 +1,6 @@
+from setuptools import setup
+
+
+setup(
+    name="disabled",
+)


### PR DESCRIPTION
This should avoid having setupmeta involved when `pip install`-ed