### PR TITLE
Changed default dirty marker to .dirty (instead of +{commitid})

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,18 @@
 History
 =======
 
+2.6.0 (2019-05-09)
+------------------
+
+* Changed default dirty marker to ``.dirty`` (instead of ``+{commitid}``)
+
+
+2.5.4 (2019-05-08)
+------------------
+
+* Run only if explicitly required via ``setup_requires=["setupmeta"]``
+
+
 2.5.3 (2019-04-29)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -31,9 +31,9 @@ Here's what your (complete, and ready to ship to pypi) ``setup.py`` could look l
     from setuptools import setup
 
     setup(
-        name='myproject',
-        versioning='distance',          # Optional, would activate tag-based versioning
-        setup_requires='setupmeta'      # This is where setupmeta comes in
+        name="myproject",
+        versioning="distance",          # Optional, would activate tag-based versioning
+        setup_requires="setupmeta"      # This is where setupmeta comes in
     )
 
 And that should be it - setupmeta_ will take it from there, extracting everything else from the rest of your project
@@ -48,15 +48,15 @@ note that a lot of info is typically extracted from your project, if you follow 
               author: (auto-adjust     ) Your Name
                   \_: (myproject.py:7  ) Your Name<your@email.com>
         author_email: (auto-adjust     ) your@email.com
-         classifiers: (classifiers.txt ) 6 items: ['Development Status :: ...
+         classifiers: (classifiers.txt ) 6 items: ["Development Status :: ...
          description: (README.rst:1    ) First line of your README
         entry_points: (entry_points.ini) [console_scripts] ...
-    install_requires: (requirements.txt) ['click', ...
+    install_requires: (requirements.txt) ["click", ...
              license: (auto-fill       ) MIT
     long_description: (README.rst      ) Long description would be your inlined README
                 name: (explicit        ) myproject
-          py_modules: (auto-fill       ) ['myproject']
-      setup_requires: (explicit        ) ['setupmeta']
+          py_modules: (auto-fill       ) ["myproject"]
+      setup_requires: (explicit        ) ["setupmeta"]
              version: (git             ) 1.2.3.post2
           versioning: (explicit        ) distance
 
@@ -116,25 +116,25 @@ How it works?
 
 * ``version`` can be stated explicitly, or be computed from git tags using ``versioning=...`` (see versioning_ for more info):
 
-    * With ``versioning='distance'``, your git tags will be of the form ``v{major}.{minor}.0``,
+    * With ``versioning="distance"``, your git tags will be of the form ``v{major}.{minor}.0``,
       the number of commits since latest version tag will be used to auto-fill the "patch" part of the version:
 
         * tag "v1.0.0", no commits since tag -> version is "1.0.0"
 
         * tag "v1.0.0", 5 commits since tag -> version is "1.0.5"
 
-        * if checkout is dirty, ``+{commitid}`` is added -> version would be "1.0.5.post5+g123"
+        * if checkout is dirty, a marker is added -> version would be "1.0.5.post5.dirty"
 
-    * With ``versioning='post'``, your git tags will be of the form ``v{major}.{minor}.{patch}``,
+    * With ``versioning="post"``, your git tags will be of the form ``v{major}.{minor}.{patch}``,
       a "post" addendum will be present if there are commits since latest version tag:
 
         * tag "v1.0.0", no commits since tag -> version is "1.0.0"
 
         * tag "v1.0.0", 5 commits since tag -> version is "1.0.0.post5"
 
-        * if checkout is dirty, ``+{commitid}`` is added -> version would be "1.0.0.post5+g123"
+        * if checkout is dirty, a marker is added -> version would be "1.0.0.post5.dirty"
 
-    * With ``versioning='build-id'``, your git tags will be of the form ``v{major}.{minor}.0``,
+    * With ``versioning="build-id"``, your git tags will be of the form ``v{major}.{minor}.0``,
       the number of commits since latest version tag will be used to auto-fill the "patch" part of the version:
 
         * tag "v1.0.0", no commits since tag, ``BUILD_ID=12`` -> version is "1.0.0+h12.g123"
@@ -145,7 +145,7 @@ How it works?
 
         * tag "v1.0.0", 5 commits since tag, ``BUILD_ID`` not defined -> version is "1.0.5+hlocal.g456"
 
-        * if checkout is dirty, ``.dirty`` is added -> version would be "1.0.5+hlocal.g456.dirty"
+        * if checkout is dirty, a marker is added -> version would be "1.0.5+hlocal.g456.dirty"
 
     * Use the **bump** command (see commands_) to easily bump (ie: increment major, minor or patch + apply git tag)
 
@@ -242,7 +242,7 @@ I noticed that most open-source projects out there do the same thing over and ov
   (copy-pasting the few lines of code to read the contents of said file)
 
 * Reading, grepping, sometimes importing a small ``__version__.py`` or ``__about__.py`` file to get values like ``__version__`` out of it,
-  and then dutifully doing ``version=__version__`` or ``version=about['__version__']`` in their ``setup.py``
+  and then dutifully doing ``version=__version__`` or ``version=about["__version__"]`` in their ``setup.py``
 
 * All kinds of creative things to get the ``description``
 

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -61,9 +61,9 @@ In the above output:
 
 * Note that ``title*`` is shown with an asterisk, the asterisk means that setupmeta sees the value and can use it, but doesn't transfer it to setuptools
 
-* ``packages`` was auto-filled to ``['setupmeta']``
+* ``packages`` was auto-filled to ``["setupmeta"]``
 
-* ``version`` was determined from git tag (due to ``versioning='post'`` in setup.py), in this case ``1.1.2.post1+g816252c`` means:
+* ``version`` was determined from git tag (due to ``versioning="post"`` in setup.py), in this case ``1.1.2.post1+g816252c`` means:
 
     * latest tag was 1.1.2
 

--- a/docs/versioning.rst
+++ b/docs/versioning.rst
@@ -18,13 +18,13 @@ The functionality is optional and has to be explicitly enabled, note that:
 In order to use setupmeta as a bridge to your git tags as versions, activate the feature by specifying one of the strategies in your ``setup.py`` like so::
 
     setup(
-        versioning='post',
+        versioning="post",
         ...
     )
 
 You can use then ``python setup.py version --bump`` to bump major/minor/patch (no need to assign tags manually).
 
-Note that if you still explicitly mention a ``__version__ = '...'``` in your ``__init__.py`` or ``__about__.py`` etc, setupmeta will find it and also bump it accordingly.
+Note that if you still explicitly mention a ``__version__ = "..."``` in your ``__init__.py`` or ``__about__.py`` etc, setupmeta will find it and also bump it accordingly.
 This is done for convenience only, you don't need ``__version__`` anywhere if you use setupmeta versioning.
 
 
@@ -43,9 +43,9 @@ Tag-based versioning will take precedence on any other ``version`` specification
 
 For example, if you have this:
 
-* ``setup(versioning='post')`` in your ``setup.py``
+* ``setup(versioning="post")`` in your ``setup.py``
 
-* ``__version__ = '1.0.0'`` in your ``__init__.py`` line 7
+* ``__version__ = "1.0.0"`` in your ``__init__.py`` line 7
 
 * ``git describe`` yields ``v1.0.0-2-g123`` (ie: latest tag is "v1.0.0", there are 2 commits since that tag, and current commit id is "123")
 
@@ -73,7 +73,7 @@ Ie:
 
 If you now run ``setup.py version --bump patch --commit``, the following would happen:
 
-* your ``__init__.py`` line 7 is modified to state ``__version__ = '1.0.1'``, and committed with description "Version 1.0.1"
+* your ``__init__.py`` line 7 is modified to state ``__version__ = "1.0.1"``, and committed with description "Version 1.0.1"
 
 * tag ``v1.0.1`` is applied at that new commit
 
@@ -83,7 +83,7 @@ If you now run ``setup.py version --bump patch --commit``, the following would h
          \_: (__init__.py:7) 1.0.1
 
 Note that you do NOT need any ``__version__ = ...`` stated anywhere, we're showing this only here for illustration purposes.
-In general, you should simply use ``versioning='post'`` (or any other format you like).
+In general, you should simply use ``versioning="post"`` (or any other format you like).
 
 You could leverage this ``__version__`` possibility if you have specific use case for that
 (like: you'd like to show which version your code is at without using something like ``import pkg_resources``)
@@ -97,12 +97,12 @@ post
 
 This is well suited if you don't plan to publish often, and have a tag for each release.
 
-``post`` corresponds to this format: ``branch(master):{major}.{minor}.{patch}{post}+{commitid}``
+``post`` corresponds to this format: ``branch(master):{major}.{minor}.{patch}{post}{dirty}``
 
 State this in your ``setup.py``::
 
     setup(
-        versioning='post',
+        versioning="post",
         ...
     )
 
@@ -206,12 +206,12 @@ distance
 
 This is well suited if you want to publish a new version at every commit (but don't want to keep bumping version in code for every commit).
 
-``distance`` corresponds to this format: ``branch(master):{major}.{minor}.{distance}+{commitid}``
+``distance`` corresponds to this format: ``branch(master):{major}.{minor}.{distance}{dirty}``
 
 State this in your ``setup.py``::
 
     setup(
-        versioning='distance',
+        versioning="distance",
         ...
     )
 
@@ -267,7 +267,7 @@ This is similar to distance_ (described above), so well suited if you want to pu
 State this in your ``setup.py``::
 
     setup(
-        versioning='build-id',
+        versioning="build-id",
         ...
     )
 
@@ -295,7 +295,7 @@ g10              1.0.1+h300.g3
 
 * Similar to distance_, except that the ``extra`` part is always shown and will reflect whether build took locally or on a CI server (which will define an env var ending with ``BUILD_ID``)
 
-* Can be easily made to act like post_ instead for the **main*** part of the version via ``versioning='post+build-id'``
+* Can be easily made to act like post_ instead for the **main*** part of the version via ``versioning="post+build-id"``
 
 
 Advanced
@@ -333,14 +333,14 @@ Advanced
     * ``branches``: list of branch names (or csv) where to allow **bump**
 
 
-This is what ``versioning='post'`` is a shortcut for::
+This is what ``versioning="post"`` is a shortcut for::
 
     setup(
         versioning={
-            'main': '{major}.{minor}.{patch}{post}',
-            'extra': '{commitid}',
-            'branches': ['master'],
-            'separator': '+'
+            "main": "{major}.{minor}.{patch}{post}",
+            "extra": "{dirty}",
+            "branches": ["master"],
+            "separator": ""
         },
         ...
     )

--- a/setupmeta/scm.py
+++ b/setupmeta/scm.py
@@ -157,6 +157,7 @@ class Git(Scm):
                 distance = setupmeta.to_int(distance, default=0)
                 commitid = setupmeta.strip_dash(m.group(3))
                 if dirty is None:
+                    # This is only settable via env var SCM_DESCRIBE
                     dirty = m.group(4) == "-dirty"
                 return Version(main, distance, commitid, dirty, text)
         return None

--- a/setupmeta/versioning.py
+++ b/setupmeta/versioning.py
@@ -287,8 +287,8 @@ class Strategy:
 
         data = dict(
             main="{major}.{minor}.{patch}{post}",
-            extra="{commitid}",
-            separator="+",
+            extra="{dirty}",
+            separator="",
             branches="master",
             hook=None,
         )
@@ -304,6 +304,7 @@ class Strategy:
             main = m.group(3)
             if main in ("distance", "build-id", "changes"):
                 if main == "build-id":
+                    data["separator"] = "+"
                     data["extra"] = "!h{$*BUILD_ID:local}.{commitid}{dirty}"
                 main = "{major}.{minor}.{distance}"
 
@@ -328,12 +329,13 @@ class Strategy:
                         main = main.replace("{post}", "{dev}")
 
                 elif extra == "build-id":
+                    data["separator"] = "+"
                     data["extra"] = "!h{$*BUILD_ID:local}.{commitid}{dirty}"
 
                 else:
                     data["extra"] = extra
 
-            if main and "{dirty}" in main and data["extra"] == "{commitid}":
+            if main and "{dirty}" in main and data["extra"] in ("{commitid}", "{dirty}"):
                 data["extra"] = None
 
             data["main"] = main

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -110,7 +110,7 @@ def test_no_scm(_):
 def test_version_from_env_var(*_):
     meta = new_meta("post")
     versioning = meta.versioning
-    assert meta.version == "1.2.3.post4+g1234567"
+    assert meta.version == "1.2.3.post4.dirty"
     assert versioning.enabled
     assert not versioning.generate_version_file
     assert not versioning.problem
@@ -130,28 +130,29 @@ def quick_check(versioning, expected, dirty=True, describe="v0.1.2-5-g123"):
 @patch.dict(os.environ, {"BUILD_ID": "543"})
 def test_versioning_variants(*_):
     with conftest.capture_output() as logged:
-        quick_check("{major}.{minor}", "0.1+g123")
+        quick_check("{major}.{minor}", "0.1.dirty")
         quick_check("{major}.{minor}+", "0.1")
         quick_check("{major}.{minor}-{dirty}", "0.1-.dirty")
         quick_check("{major}.{minor}{dirty}", "0.1.dirty")
         quick_check("{major}.{minor}{dirty}+", "0.1.dirty")
         quick_check("{major}.{minor}", "0.1", dirty=False)
 
-        quick_check("distance", "0.1.5+g123")
-        quick_check("post", "0.1.2.post5+g123")
-        quick_check("dev", "0.1.3.dev5+g123")
+        quick_check("distance", "0.1.5.dirty")
+        quick_check("post", "0.1.2.post5.dirty")
+        quick_check("dev", "0.1.3.dev5.dirty")
         quick_check("devcommit", "0.1.3.dev-g123", dirty=False)
         quick_check("devcommit", "0.1.3.dev-g123-dirty")
-        quick_check("tag+dev", "0.1.3.dev5+g123")
+        quick_check("tag dev", "0.1.3.dev5.dirty")
+        quick_check("tag+dev", "0.1.3.dev5+.dirty")
         quick_check("build-id", "0.1.5+h543.g123.dirty")
         quick_check("dev+build-id", "0.1.3.dev5+h543.g123.dirty")
 
         # Patch is not bumpable
-        quick_check("dev", "0.1.rc.dev5+g123", describe="v0.1.rc-5-g123")
+        quick_check("dev", "0.1.rc.dev5.dirty", describe="v0.1.rc-5-g123")
 
         # On tag
         quick_check("dev", "0.1.2", describe="v0.1.2-0-g123", dirty=False)
-        quick_check("dev", "0.1.3.dev0+g123", describe="v0.1.2-0-g123", dirty=True)
+        quick_check("dev", "0.1.3.dev0.dirty", describe="v0.1.2-0-g123", dirty=True)
         quick_check("devcommit", "0.1.2", describe="v0.1.2", dirty=False)
         quick_check("devcommit", "0.1.2", describe="v0.1.2-0-g123", dirty=False)
         quick_check("devcommit", "0.1.3.dev-g123-dirty", describe="v0.1.2-0-g123", dirty=True)
@@ -241,16 +242,16 @@ def test_distance_marker():
         assert versioning.enabled
         assert not versioning.problem
         assert not versioning.strategy.problem
-        assert meta.version == "0.1.3+g123"
-        assert str(versioning.strategy) == "branch(master):{major}.{minor}.{distance}+{commitid}"
+        assert meta.version == "0.1.3.dirty"
+        assert str(versioning.strategy) == "branch(master):{major}.{minor}.{distance}{dirty}"
 
 
 @patch.dict(os.environ, {"BUILD_ID": "543"})
 def test_preconfigured_build_id(*_):
     """Verify that short notations expand to the expected format"""
-    check_preconfigured("branch(master):{major}.{minor}.{patch}{post}+{commitid}", "post", "default")
+    check_preconfigured("branch(master):{major}.{minor}.{patch}{post}{dirty}", "post", "default")
 
-    check_preconfigured("branch(master):{major}.{minor}.{distance}+{commitid}", "distance")
+    check_preconfigured("branch(master):{major}.{minor}.{distance}{dirty}", "distance")
 
     check_preconfigured("branch(master):{major}.{minor}.{distance}+!h{$*BUILD_ID:local}.{commitid}{dirty}", "build-id", "distance+build-id")
 
@@ -289,10 +290,10 @@ def check_strategy_distance(dirty):
     assert not versioning.problem
     assert not versioning.strategy.problem
     assert "major" in str(versioning.strategy.main_bits)
-    assert "commitid" in str(versioning.strategy.extra_bits)
-    assert str(versioning.strategy) == "branch(master):{major}.{minor}.{distance}+{commitid}"
+    assert "dirty" in str(versioning.strategy.extra_bits)
+    assert str(versioning.strategy) == "branch(master):{major}.{minor}.{distance}{dirty}"
     if dirty:
-        assert meta.version == "0.1.3+g123"
+        assert meta.version == "0.1.3.dirty"
 
         with pytest.raises(setupmeta.UsageError):
             # Can't effectively bump if checkout is dirty


### PR DESCRIPTION
Originally default dirty marker was `+{comitid}`, leading to some confusion as to why my version is `1.0.0+g1234567`.

The intent of `{commitid}` was to carry more info (git commit id as dirty marker), but it's not that useful after all, and is not immediately obvious that this is indeed the dirty marker...

Changing default dirty marker to simply `.dirty`, which should make it obvious why one gets for example `1.0.0.dirty` as version.