### PR TITLE
version: git: use --first-parent with git-describe

### DIFF
--- a/setupmeta/scm.py
+++ b/setupmeta/scm.py
@@ -180,7 +180,7 @@ class Git(Scm):
 
     def get_version(self):
         dirty = self.is_dirty()
-        text = self.get_output("describe", "--tags", "--long", "--match", "*.*")
+        text = self.get_output("describe", "--tags", "--long", "--match", "*.*", "--first-parent")
         version = self.parsed_version(text, dirty)
         if version:
             return version


### PR DESCRIPTION
This will ignore tags from merged release branches.