### PR TITLE
Use SETUPMETA_GIT_DESCRIBE_COMMAND

### DIFF
--- a/docs/versioning.rst
+++ b/docs/versioning.rst
@@ -37,7 +37,7 @@ How does it work?
 
 you will need **git version >= 1.8.4** if you wish to use ``setupmeta``'s versioning capabilities.
 
-You can modify the above command via environment variable ``GIT_DESCRIBE_COMMAND`` (give full git command if you do).
+You can modify the above command via environment variable ``SETUPMETA_GIT_DESCRIBE_COMMAND`` (give full git command if you do).
 
 ----
 

--- a/setupmeta/scm.py
+++ b/setupmeta/scm.py
@@ -180,8 +180,8 @@ class Git(Scm):
 
     def get_version(self):
         dirty = self.is_dirty()
-        # Allow to override git describe command via env var GIT_DESCRIBE_COMMAND (just in case)
-        cmd = os.environ.get("GIT_DESCRIBE_COMMAND", "describe --dirty --tags --long --match *.* --first-parent")
+        # Allow to override git describe command via env var SETUPMETA_GIT_DESCRIBE_COMMAND (just in case)
+        cmd = os.environ.get("SETUPMETA_GIT_DESCRIBE_COMMAND", "describe --dirty --tags --long --match *.* --first-parent")
         cmd = cmd.split(" ")
         text = self.get_output(*cmd)
         version = self.parsed_version(text, dirty)


### PR DESCRIPTION
I think it makes sense to use "SETUPMETA_" as a prefix here.

Not sure if it should fall back to the one without the prefix.