### PR TITLE
Handle migration of PipSession to new package in pip>=19.3

### DIFF
--- a/setupmeta/model.py
+++ b/setupmeta/model.py
@@ -311,6 +311,16 @@ def get_pip():
         return parse_requirements, PipSession
 
     except ImportError:
+        pass
+
+    try:
+        # pip >= 19.3
+        from pip._internal.req import parse_requirements
+        from pip._internal.network.session import PipSession
+
+        return parse_requirements, PipSession
+
+    except ImportError:
         setupmeta.warn("Can't find PipSession, won't auto-fill requirements")
         return None, None
 


### PR DESCRIPTION
From `pip>=19.3`, the `PipSession` class has moved to a new package, resulting in the following error:

```
UserWarning: Can't find PipSession, won't auto-fill requirements
  setupmeta.warn("Can't find PipSession, won't auto-fill requirements")
```

This PR adds an additional case to check for this situation.