### PR TITLE
Removed support for python 3.4, added tests

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,14 @@
 History
 =======
 
+2.6.17 (2020-01-24)
+-------------------
+
+* Adapted ``get_pip()`` call to pip 20.0 API change
+
+* Removed support for python 3.4 (not accepted by pypi anymore)
+
+
 2.6.15 (2020-01-14)
 -------------------
 

--- a/classifiers.txt
+++ b/classifiers.txt
@@ -10,7 +10,6 @@ Programming Language :: Python
 Programming Language :: Python :: 2
 Programming Language :: Python :: 2.7
 Programming Language :: Python :: 3
-Programming Language :: Python :: 3.4
 Programming Language :: Python :: 3.5
 Programming Language :: Python :: 3.6
 Programming Language :: Python :: 3.7

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -102,7 +102,20 @@ def test_no_pip():
         with patch.dict("sys.modules", {"pip.req": MagicMock(), "pip.download": MagicMock()}):
             assert len(get_pip()) == 2
 
+        # Simulate 10.0 < pip < 20.0
+        with patch.dict(
+            "sys.modules", {"pip._internal.req": MagicMock(), "pip._internal.download": MagicMock(), "pip._internal.network.session": None}
+        ):
+            assert len(get_pip()) == 2
+
+        # Simulate pip > 20.0
+        with patch.dict(
+            "sys.modules", {"pip._internal.req": MagicMock(), "pip._internal.download": None, "pip._internal.network.session": MagicMock()}
+        ):
+            assert len(get_pip()) == 2
+
         # Simulate pip not installed at all
         with patch.dict("sys.modules", {"pip": None, "pip._internal.req": None, "pip.req": None}):
             assert get_pip() == (None, None)
+
         assert "Can't find PipSession" in logged

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,35,36,37,38}, docs, style, security
+envlist = py{27,35,36,37,38}, docs, style, security
 skip_missing_interpreters = true
 
 


### PR DESCRIPTION
Python 3.4 publications are not accepted anymore by pypi:
```
2020-01-24 18:58:36 URL:https://bootstrap.pypa.io/get-pip.py [1807317/1807317] -> "-" [1]
...
RuntimeError: Python 3.5 or later is required

Couldn't install pip, setuptools, twine or wheel.
```