### PR TITLE
Added requirements_from_text() and requirements_from_file()

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,8 @@ History
 2.7.1 (2020-04-30)
 -------------------
 
+* Added ``requirements_from_text()`` and ``requirements_from_file()``
+
 * Consistently apply auto-abstraction to ``tests_require`` as well
 
 * Internally use consistent names for ``install_requires``, ``tests_require`` and ``extras_require``

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,8 @@ History
 
 * Added ``requirements_from_text()`` and ``requirements_from_file()``
 
+* Use a regex to determine simple pins of the form ``foo==1.0``
+
 * Consistently apply auto-abstraction to ``tests_require`` as well
 
 * Internally use consistent names for ``install_requires``, ``tests_require`` and ``extras_require``

--- a/setupmeta/__init__.py
+++ b/setupmeta/__init__.py
@@ -379,9 +379,10 @@ def requirements_from_text(text):
     """Transform contents of a requirements.txt file to an appropriate form for install_requires
     Example:
         foo==1.0
-        bar
+        bar==2.0; python_version >= '3.6'
+        baz>=1.2
 
-    Transformed to: ["foo", "bar"]
+    Transformed to: ["foo", "bar; python_version >= '3.6'", "baz>=1.2"]
 
     :param str text: Contents (text) of a requirements.txt file
     :return list: List of parsed and abstracted requirements
@@ -394,9 +395,10 @@ def requirements_from_file(path):
     """Transform contents of a requirements.txt file to an appropriate form for install_requires
     Example:
         foo==1.0
-        bar
+        bar==2.0; python_version >= '3.6'
+        baz>=1.2
 
-    Transformed to: ["foo", "bar"]
+    Transformed to: ["foo", "bar; python_version >= '3.6'", "baz>=1.2"]
 
     :param str path: Path of requirements.txt file to read
     :return list|None: List of parsed and abstracted requirements

--- a/tests/scenarios/disabled/requirements.txt
+++ b/tests/scenarios/disabled/requirements.txt
@@ -1,5 +1,6 @@
 chardet==3.0.4
 coverage>=5.0  # indirect
+foo_bar==1.0; python_version >= '3.6'
 
 # Unknown [] sections ignored
 [:python_version < "3.7"]
@@ -7,7 +8,7 @@ requests
 
 # URLs properly auto-filled as dependency_links
 [foo]
--e git://a.b/c/p1.git#egg=runez
+-e git://a.b/c/p1.git#egg=my_egg
 some-project @ https://a.b/c/p2.git@u/pp
 
 # Folders taken as-is

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -62,13 +62,13 @@ def test_requirements():
 
     sample = conftest.resouce("scenarios/disabled/requirements.txt")
     f = setupmeta.RequirementsFile.from_file(sample)
-    assert len(f.lines) == 15
+    assert len(f.lines) == 16
     assert str(f.lines[0]) == "chardet==3.0.4"
-    assert f.filled_requirements == ["chardet", "requests", "runez", "some-project"]
-    assert f.dependency_links == ["git+git://a.b/c/p1.git#egg=runez", "https://a.b/c/p2.git@u/pp", "file:///tmp/bar1", "file:///tmp/bar2"]
-    assert f.abstracted == ["chardet  # abstracted by default"]
+    assert f.filled_requirements == ["chardet", "foo_bar; python_version >= '3.6'", "requests", "my_egg", "some-project"]
+    assert f.dependency_links == ["git+git://a.b/c/p1.git#egg=my_egg", "https://a.b/c/p2.git@u/pp", "file:///tmp/bar1", "file:///tmp/bar2"]
+    assert f.abstracted == ["chardet  # abstracted by default", "foo_bar; python_version >= '3.6'  # abstracted by default"]
     assert f.ignored == ["coverage>=5.0  # 'indirect' stated on line"]
-    assert f.untouched == ["requests", "runez", "some-project"]
+    assert f.untouched == ["requests", "my_egg", "some-project"]
 
     fr = setupmeta.requirements_from_file(sample)
     assert fr == f.filled_requirements


### PR DESCRIPTION
Allow for programmatic use like
```
from setupmeta import requirements_from_text

my_reqs = """
a
b==1.0
"""

reqs = requirements_from_text(my_reqs)

assert reqs == ["a", "b"]
```