### PR TITLE
Simplify hooks, and fix preprocessing not triggering when not already installed in environment.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,9 +20,12 @@ explain = setupmeta.commands:ExplainCommand
 twine = setupmeta.commands:TwineCommand
 version = setupmeta.commands:VersionCommand
 
+[setuptools.finalize_distribution_options]
+setupmeta = setupmeta.hook:finalize_dist
+
 [distutils.setup_keywords]
-setup_requires = setupmeta.hook:register
-versioning = setupmeta.hook:register
+setup_requires = setupmeta.hook:register_keyword
+versioning = setupmeta.hook:register_keyword
 """
 
 


### PR DESCRIPTION
This patch simplifies the way that `setupmeta` hooks into the lifecycle of the `Distribution` classes, and makes the preprocessing step actually work when `setupmeta` is not already installed in the relevant python environment.